### PR TITLE
patch for v20 account types

### DIFF
--- a/core/api_core.js
+++ b/core/api_core.js
@@ -12,6 +12,7 @@ var core = function(options) {
   this.setToken(options.token);
   this.setEndpoint(options.type);
   this.setDatetimeFormat(options.dateFormat);
+  this.setApiVersion(options.version);
   this.requestUrlFormatter = new UrlFormatter(this.request_endpoint);
   this.streamUrlFormatter = new UrlFormatter(this.stream_endpoint);
 
@@ -56,6 +57,24 @@ core.prototype = {
 
     this.log('request_endpoint: ' + this.request_endpoint);
     this.log('stream_endpoint: ' + this.stream_endpoint);
+  },
+
+  setApiVersion: function(version) {
+
+      switch(version) {
+          case 'legacy':
+            this.apiVersion = 'v1';
+            break;
+          case 'v20':
+            this.apiVersion = 'v3';
+            break;
+          default:
+            this.apiVersion = 'v1';
+            break;
+      }
+
+      this.log('apiVersion: ' + this.apiVersion);
+
   },
 
   setDatetimeFormat: function(type) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var util = require('./core/oanda_util');
 var Oanda = function(options) {
   options = util.define(options, {});
   options.silent = util.define(options.silent, true);
-  
+
   this._options = options;
   this.setCore(ApiCore);
 };

--- a/requests/accounts.js
+++ b/requests/accounts.js
@@ -7,8 +7,7 @@ var accounts = function(core) {
 accounts.prototype = {
   getAccountsForUser: function(options) {
     options = util.define(options, {});
-
-    return this.core.request('/v1/accounts', 'GET', options);
+    return this.core.request(`/${this.core.apiVersion}/accounts`, 'GET', options);
   },
 
   getAccountInformation: function(account_id) {
@@ -16,7 +15,7 @@ accounts.prototype = {
       account_id: account_id
     }
 
-    return this.core.request('/v1/accounts/:account_id', 'GET', options);
+    return this.core.request(`/${this.core.apiVersion}/accounts/:account_id`, 'GET', options);
   }
 };
 

--- a/requests/history.js
+++ b/requests/history.js
@@ -10,7 +10,7 @@ history.prototype = {
     options.account_id = account_id;
 
     return this.core.request(
-      '/v1/accounts/:account_id/transactions', 'GET', options);
+      `/${this.core.apiVersion}/accounts/:account_id/transactions`, 'GET', options);
   },
 
   getInformationForTransaction: function(account_id, transation_id) {
@@ -20,7 +20,7 @@ history.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/transactions/:transaction_id', 'GET', options);
+      `/${this.core.apiVersion}/accounts/:account_id/transactions/:transaction_id`, 'GET', options);
   },
 
   getFullAccountHistory: function(account_id) {
@@ -29,7 +29,7 @@ history.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/alltransactions', 'GET', options);
+      `/${this.core.apiVersion}/accounts/:account_id/alltransactions`, 'GET', options);
   }
 };
 

--- a/requests/orders.js
+++ b/requests/orders.js
@@ -10,7 +10,7 @@ orders.prototype = {
     options.account_id = account_id;
 
     return this.core.request(
-      '/v1/accounts/:account_id/orders', 'GET', options);
+      '/${this.core.apiVersion}/accounts/:account_id/orders', 'GET', options);
   },
 
   createNewOrder: function(account_id, instrument, units, side, type, expiry, price, options) {
@@ -24,7 +24,7 @@ orders.prototype = {
     options.price = price;
 
     return this.core.request(
-      '/v1/accounts/:account_id/orders', 'POST', options);
+      `/${this.core.apiVersion}/accounts/:account_id/orders`, 'POST', options);
   },
 
   getInformationForOrder: function(account_id, order_id) {
@@ -34,7 +34,7 @@ orders.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/orders/:order_id', 'GET', options);
+      `/${this.core.apiVersion}/accounts/:account_id/orders/:order_id`, 'GET', options);
   },
 
   modifyExistingOrder: function(account_id, order_id, options) {
@@ -43,7 +43,7 @@ orders.prototype = {
     options.order_id = order_id;
 
     return this.core.request(
-      '/v1/accounts/:account_id/orders/:order_id', 'PATCH', options);
+      `/${this.core.apiVersion}/accounts/:account_id/orders/:order_id`, 'PATCH', options);
   },
 
   closeOrder: function(account_id, order_id) {
@@ -53,7 +53,7 @@ orders.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/orders/:order_id', 'DELETE', options);
+      `/${this.core.apiVersion}/accounts/:account_id/orders/:order_id`, 'DELETE', options);
   }
 };
 

--- a/requests/positions.js
+++ b/requests/positions.js
@@ -9,7 +9,7 @@ positions.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/positions', 'GET', options);
+      `/#{this.core.apiVersion}/accounts/:account_id/positions`, 'GET', options);
   },
 
   getPositionForInstrument: function(account_id, instrument) {
@@ -19,7 +19,7 @@ positions.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/positions/:instrument', 'GET', options);
+      `/#{this.core.apiVersion}/accounts/:account_id/positions/:instrument`, 'GET', options);
   },
 
   closeExistingPosition: function(account_id, instrument) {
@@ -29,7 +29,7 @@ positions.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/positions/:instrument', 'DELETE', options);
+      `/#{this.core.apiVersion}/accounts/:account_id/positions/:instrument`, 'DELETE', options);
   }
 };
 

--- a/requests/rates.js
+++ b/requests/rates.js
@@ -10,7 +10,7 @@ rates.prototype = {
     options.account_id = account_id;
 
     return this.core.request(
-      '/v1/instruments', 'GET', options);
+      `/${this.core.apiVersion}/instruments`, 'GET', options);
   },
 
   getCurrentPrices: function(instruments, options) {
@@ -18,7 +18,7 @@ rates.prototype = {
     options.instruments = util.encodeArray(instruments);
 
     return this.core.request(
-      '/v1/instruments', 'GET', options);
+      `/${this.core.apiVersion}/instruments`, 'GET', options);
   },
 
   retrieveInstrumentHistory: function(instrument, options) {
@@ -26,7 +26,7 @@ rates.prototype = {
     options.instrument = instrument;
 
     return this.core.request(
-      '/v1/candles', 'GET', options);
+      `/${this.core.apiVersion}/candles`, 'GET', options);
   }
 };
 

--- a/requests/streams.js
+++ b/requests/streams.js
@@ -10,7 +10,7 @@ streams.prototype = {
     options.accountId = account_id;
     options.instruments = util.encodeArray(instruments);
 
-    return this.core.stream('/v1/prices', options);
+    return this.core.stream(`/${this.core.apiVersion}/prices`, options);
   }
 };
 

--- a/requests/trades.js
+++ b/requests/trades.js
@@ -10,7 +10,7 @@ trades.prototype = {
     options.account_id = account_id;
 
     return this.core.request(
-      '/v1/accounts/:account_id/trades', 'GET', options);
+      `/${this.core.apiVersion}/accounts/:account_id/trades`, 'GET', options);
   },
 
   getInformationOnSpecificTrade: function(account_id, trade_id) {
@@ -20,7 +20,7 @@ trades.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/trades/:trade_id', 'GET', options);
+      `/${this.core.apiVersion}/accounts/:account_id/trades/:trade_id`, 'GET', options);
   },
 
   modifyExistingTrade: function(account_id, trade_id, options) {
@@ -29,7 +29,7 @@ trades.prototype = {
     options.trade_id = trade_id;
 
     return this.core.request(
-      '/v1/accounts/:account_id/trades/:trade_id', 'PATCH', options);
+      `/${this.core.apiVersion}/accounts/:account_id/trades/:trade_id`, 'PATCH', options);
   },
 
   closeOpenTrade: function(account_id, trade_id) {
@@ -39,7 +39,7 @@ trades.prototype = {
     };
 
     return this.core.request(
-      '/v1/accounts/:account_id/trades/:trade_id', 'DELETE', options);
+      `/${this.core.apiVersion}/accounts/:account_id/trades/:trade_id`, 'DELETE', options);
   }
 };
 


### PR DESCRIPTION
Oanda released a v20 of their API vs. their Legacy API.

With this new addition, the path differs between API versions:

Example:
Legacy API: /v1/accounts/
v20 API: /v3/accounts/

This pull request adds a 4th field to the config object sent through the ApiCore.

Depending on the version provided the API path will be dynamic to /v1/ or /v3/, defaulting to /v1/