### PR TITLE
Fixed request path option, it should be ROUTES.pricing

### DIFF
--- a/src/requests/pricing.js
+++ b/src/requests/pricing.js
@@ -2,7 +2,7 @@ const ROUTES = require('../routes');
 const utils = require('../utils');
 const { HTTP_METHOD } = require('../constant');
 
-module.exports = class TradeAPI {
+module.exports = class PricingAPI {
 
   /**
    * This API can be used to access all Oanda V2 Pricing endpoints
@@ -23,7 +23,7 @@ module.exports = class TradeAPI {
 
     return this.request({
       method: HTTP_METHOD.GET,
-      path: ROUTES.position.getInstrumentPricing,
+      path: ROUTES.pricing.getInstrumentPricing,
       params: {
         account_id: account_id
       },

--- a/src/routes.json
+++ b/src/routes.json
@@ -15,7 +15,7 @@
   },
 
   "order": {
-    "createOrder": "/accounts",
+    "createOrder": "/accounts/{account_id}/orders",
     "listOrders": "/accounts/{account_id}/orders",
     "listPendingOrders": "/accounts/{account_id}/orders",
     "getOrder": "/accounts/{account_id}/orders/{order_specifier}",


### PR DESCRIPTION
Hi @flagpoonage, thanks for creating this library. I've encountered a small issue while trying to call getInstrumentPricing. The issue is caused by request path is pointing to ROUTES.position instead of pricing. I have applied the fix on this pull request.